### PR TITLE
Change the scope of the variable PODS to local

### DIFF
--- a/runonce.sh
+++ b/runonce.sh
@@ -7,18 +7,21 @@ set -euo pipefail
 function main() {
   kubectl apply -f configmap.yaml
   kubectl apply -f daemonset.yaml
-  wait_for_pods ssm-agent-installer
-  wait_for_success ssm-agent-installer
+
+  local -r DAEMONSET_NAME="ssm-agent-installer"
+  local -r PODS="$(kubectl get pods | grep -i "${DAEMONSET_NAME}" | awk '{print $1}')"
+  
+  wait_for_pods
+  wait_for_success
+
   kubectl delete -f daemonset.yaml
 }
 
 function wait_for_pods() {
-  echo -n "waiting for $1 pods to run"
-
-  PODS=$(kubectl get pods | grep $1 | awk '{print $1}')
+  echo -n "waiting for ${DAEMONSET_NAME} pods to run"
 
   for POD in ${PODS}; do
-    while [[ $(kubectl get pod ${POD} -o go-template --template "{{.status.phase}}") != "Running" ]]; do
+    while [[ "$(kubectl get pod "${POD}" -o go-template --template "{{.status.phase}}")" != "Running" ]]; do
       sleep 1
       echo -n "."
     done
@@ -28,12 +31,10 @@ function wait_for_pods() {
 }
 
 function wait_for_success() {
-  echo -n "waiting for $1 daemonset to complete"
-
-  PODS=$(kubectl get pods | grep $1 | awk '{print $1}')
+  echo -n "waiting for ${DAEMONSET_NAME} daemonset to complete"
 
   for POD in ${PODS}; do
-    while [[ $(kubectl logs ${POD} --tail 1) != "Success" ]]; do
+    while [[ $(kubectl logs "${POD}" --tail 1) != "Success" ]]; do
       sleep 1
       echo -n "."
     done


### PR DESCRIPTION
Declare the variable DAEMONSET_NAME and move the PODS variable to the main Function

*Issue #, if available:*
#1 

*Description of changes:*
Change the scope of the variable `PODS` to local and set it as read-only.
Declare the variable `DAEMONSET_NAME` in the `main` function and move `PODS` variable to the `main` function.

*Extra comments*
A local variable is accessible only in the current function and by subprocess/functions inside of that function.
A read-only variable can't be declared multiple times. In case there is another variable with the same name, Bash will return with an error (e.g.: `bash: PODS: readonly variable`).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
